### PR TITLE
Fixes to accommodate updated version of WeightIt

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: MatchThem
 Title: Matching and Weighting Multiply Imputed Datasets
 Description: Provides essential tools for the pre-processing techniques of matching and weighting multiply imputed datasets. The package includes functions for matching within and across multiply imputed datasets using various methods, estimating weights for units in the imputed datasets using multiple weighting methods, calculating causal effect estimates in each matched or weighted dataset using parametric or non-parametric statistical models, and pooling the resulting estimates according to Rubin's rules (please see <https://journal.r-project.org/archive/2021/RJ-2021-073/> for more details).
-Version: 1.2.0
+Version: 1.2.1
 Authors@R: c(person("Farhad", "Pishgar", role = c("aut", "cre"), email = "Farhad.Pishgar@Gmail.com"),
              person("Noah", "Greifer", role = "aut", email = "noah.greifer@gmail.com",
 	                  comment = c(ORCID = "0000-0003-3067-7154")),
@@ -17,7 +17,7 @@ License: GPL (>= 2)
 Encoding: UTF-8
 LazyData: true
 VignetteBuilder: R.rsp
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 NeedsCompilation: no
 Author: Farhad Pishgar [aut, cre],
   Noah Greifer [aut],

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,10 @@
 
 ## What's New
 
+### Version 1.2.1
+
+Added support for using `glm_weightit()` in the outcome model after weighting using `weightthem()`. Other documentation updates.
+
 ### Version 1.2.0
 
 New functions `as.mimids()` and `as.wimids()` are now available; these take a list of `matchit` or `weightit` objects fit to multiply imputed data and transform them into a `mimids` or `wimids` object, respectively, for use in balance assessment and to take advantage of `MatchThem`'s other capabilities.

--- a/R/cbind.R
+++ b/R/cbind.R
@@ -20,7 +20,6 @@
 #' @export
 #'
 #' @examples \donttest{#Loading libraries
-#' library(MatchThem)
 #' library(survey)
 #'
 #' #Loading the dataset

--- a/R/complete.R
+++ b/R/complete.R
@@ -25,9 +25,7 @@
 #'
 #' @export complete
 #'
-#' @examples \donttest{#Loading libraries
-#' library(MatchThem)
-#'
+#' @examples \donttest{
 #' #Loading the dataset
 #' data(osteoarthritis)
 #'

--- a/R/is.R
+++ b/R/is.R
@@ -20,10 +20,7 @@
 #'
 #' @export
 #'
-#' @examples \donttest{#Loading libraries
-#' library(MatchThem)
-#'
-#' #Loading the dataset
+#' @examples \donttest{#Loading the dataset
 #' data(osteoarthritis)
 #'
 #' #Multiply imputing the missing values
@@ -66,10 +63,7 @@ is.mimids <- function(object) {
 #'
 #' @export
 #'
-#' @examples \donttest{#Loading libraries
-#' library(MatchThem)
-#'
-#' #Loading the dataset
+#' @examples \donttest{#Loading the dataset
 #' data(osteoarthritis)
 #'
 #' #Multiply imputing the missing values
@@ -79,7 +73,7 @@ is.mimids <- function(object) {
 #' weighted.datasets <- weightthem(OSP ~ AGE + SEX + BMI + RAC + SMK,
 #'                                 imputed.datasets,
 #'                                 approach = 'within',
-#'                                 method = 'ps',
+#'                                 method = 'glm',
 #'                                 estimand = "ATT")
 #'
 #' #Checking the 'weighted.datasets' object
@@ -114,7 +108,6 @@ is.wimids <- function(object) {
 #' @export
 #'
 #' @examples \donttest{#Loading libraries
-#' library(MatchThem)
 #' library(survey)
 #'
 #' #Loading the dataset
@@ -127,12 +120,12 @@ is.wimids <- function(object) {
 #' weighted.datasets <- weightthem(OSP ~ AGE + SEX + BMI + RAC + SMK,
 #'                                 imputed.datasets,
 #'                                 approach = 'within',
-#'                                 method = 'ps',
+#'                                 method = 'glm',
 #'                                 estimand = "ATT")
 #'
 #' #Analyzing the weighted datasets
-#' models <- with(data = weighted.datasets,
-#'                exp = svyglm(KOA ~ OSP, family = binomial))
+#' models <- with(weighted.datasets,
+#'                svyglm(KOA ~ OSP, family = binomial))
 #'
 #' #Checking the 'models' object
 #' is.mimira(models)}
@@ -166,7 +159,6 @@ is.mimira <- function(object) {
 #' @export
 #'
 #' @examples \donttest{#Loading libraries
-#' library(MatchThem)
 #' library(survey)
 #'
 #' #Loading the dataset
@@ -179,7 +171,7 @@ is.mimira <- function(object) {
 #' weighted.datasets <- weightthem(OSP ~ AGE + SEX + BMI + RAC + SMK,
 #'                                 imputed.datasets,
 #'                                 approach = 'within',
-#'                                 method = 'ps',
+#'                                 method = 'glm',
 #'                                 estimand = "ATT")
 #'
 #' #Analyzing the weighted datasets

--- a/R/matchthem.R
+++ b/R/matchthem.R
@@ -34,9 +34,6 @@
 #'
 #' @examples \donttest{#1
 #'
-#' #Loading libraries
-#' library(MatchThem)
-#'
 #' #Loading the dataset
 #' data(osteoarthritis)
 #'
@@ -50,9 +47,6 @@
 #'                               method = 'nearest')
 #'
 #' #2
-#'
-#' #Loading libraries
-#' library(MatchThem)
 #'
 #' #Loading the dataset
 #' data(osteoarthritis)

--- a/R/pool.R
+++ b/R/pool.R
@@ -28,9 +28,6 @@
 #' @export
 #'
 #' @examples \donttest{#Loading libraries
-#' library(MatchThem)
-#' library(survey)
-#'
 #' #Loading the dataset
 #' data(osteoarthritis)
 #'
@@ -41,11 +38,12 @@
 #' weighted.datasets <- weightthem(OSP ~ AGE + SEX + BMI + RAC + SMK,
 #'                                 imputed.datasets,
 #'                                 approach = 'within',
-#'                                 method = 'ps')
+#'                                 method = 'glm')
 #'
 #' #Analyzing the weighted datasets
 #' models <- with(weighted.datasets,
-#'                svyglm(KOA ~ OSP, family = quasibinomial))
+#'                WeightIt::glm_weightit(KOA ~ OSP,
+#'                                       family = binomial))
 #'
 #' #Pooling results obtained from analyzing the datasets
 #' results <- pool(models)

--- a/R/trim.R
+++ b/R/trim.R
@@ -7,7 +7,7 @@
 #' @aliases trim trim.wimids
 #'
 #' @inheritParams WeightIt::trim
-#' @param w A `wimids` object; the output of a call to [`weightthem()`][weightthem].
+#' @param x A `wimids` object; the output of a call to [`weightthem()`][weightthem].
 #' @param ... Ignored.
 #'
 #' @description Trims (i.e., truncates) large weights by setting all weights higher than that at a given quantile to the weight at the quantile. This can be useful in controlling extreme weights, which can reduce effective sample size by enlarging the variability of the weights.
@@ -22,10 +22,7 @@
 #'
 #' @export trim
 #'
-#' @examples \donttest{#Loading libraries
-#' library(MatchThem)
-#'
-#' #Loading the dataset
+#' @examples \donttest{#Loading the dataset
 #' data(osteoarthritis)
 #'
 #' #Multiply imputing the missing values
@@ -35,7 +32,7 @@
 #' weighted.datasets <- weightthem(OSP ~ AGE + SEX + BMI + RAC + SMK,
 #'                                 imputed.datasets,
 #'                                 approach = 'within',
-#'                                 method = 'ps',
+#'                                 method = 'glm',
 #'                                 estimand = "ATE")
 #'
 #' #Trimming the top 10% of weights in each dataset
@@ -46,7 +43,7 @@
 #'
 #' @export
 
-trim.wimids <- function (w, at = 0, lower = FALSE, ...) {
+trim.wimids <- function (x, at = 0, lower = FALSE, ...) {
 
   #External function
 
@@ -55,8 +52,8 @@ trim.wimids <- function (w, at = 0, lower = FALSE, ...) {
   WeightIt::trim
   #' @export
 
-  for (i in seq_along(w$models)) {
-    suppressMessages(w$models[[i]] <- WeightIt::trim(w$models[[i]], at = at, lower = lower, ...))
+  for (i in seq_along(x$models)) {
+    suppressMessages(x$models[[i]] <- WeightIt::trim(x$models[[i]], at = at, lower = lower, ...))
   }
-  return(w)
+  return(x)
 }

--- a/man/cbind.Rd
+++ b/man/cbind.Rd
@@ -25,7 +25,6 @@ This function combines a \code{\link{mimids}} or \code{\link{wimids}} object col
 }
 \examples{
 \donttest{#Loading libraries
-library(MatchThem)
 library(survey)
 
 #Loading the dataset

--- a/man/complete.Rd
+++ b/man/complete.Rd
@@ -33,9 +33,7 @@ This function returns the imputed dataset within the supplied \code{mimids} or \
 \code{complete()} works by running \code{\link[mice:complete.mids]{mice::complete()}} on the \code{mids} object stored within the \code{mimids} or \code{wimids} object and appending the outputs of the matching or weighting procedure. For \code{mimids} objects, the appended outputs include the matching weights, the propensity score (if included), pair membership (if included), and whether each unit was discarded. For \code{wimids} objects, the appended output is the estimated weights.
 }
 \examples{
-\donttest{#Loading libraries
-library(MatchThem)
-
+\donttest{
 #Loading the dataset
 data(osteoarthritis)
 

--- a/man/is.mimids.Rd
+++ b/man/is.mimids.Rd
@@ -19,10 +19,7 @@ This function returns a logical value indicating whether \code{object} is of the
 The class of objects is checked to be of the \code{mimids}.
 }
 \examples{
-\donttest{#Loading libraries
-library(MatchThem)
-
-#Loading the dataset
+\donttest{#Loading the dataset
 data(osteoarthritis)
 
 #Multiply imputing the missing values

--- a/man/is.mimipo.Rd
+++ b/man/is.mimipo.Rd
@@ -20,7 +20,6 @@ The class of objects is checked to be of the \code{mimipo}.
 }
 \examples{
 \donttest{#Loading libraries
-library(MatchThem)
 library(survey)
 
 #Loading the dataset
@@ -33,7 +32,7 @@ imputed.datasets <- mice::mice(osteoarthritis, m = 5)
 weighted.datasets <- weightthem(OSP ~ AGE + SEX + BMI + RAC + SMK,
                                 imputed.datasets,
                                 approach = 'within',
-                                method = 'ps',
+                                method = 'glm',
                                 estimand = "ATT")
 
 #Analyzing the weighted datasets

--- a/man/is.mimira.Rd
+++ b/man/is.mimira.Rd
@@ -20,7 +20,6 @@ The class of objects is checked to be of the \code{mimira}.
 }
 \examples{
 \donttest{#Loading libraries
-library(MatchThem)
 library(survey)
 
 #Loading the dataset
@@ -33,12 +32,12 @@ imputed.datasets <- mice::mice(osteoarthritis, m = 5)
 weighted.datasets <- weightthem(OSP ~ AGE + SEX + BMI + RAC + SMK,
                                 imputed.datasets,
                                 approach = 'within',
-                                method = 'ps',
+                                method = 'glm',
                                 estimand = "ATT")
 
 #Analyzing the weighted datasets
-models <- with(data = weighted.datasets,
-               exp = svyglm(KOA ~ OSP, family = binomial))
+models <- with(weighted.datasets,
+               svyglm(KOA ~ OSP, family = binomial))
 
 #Checking the 'models' object
 is.mimira(models)}

--- a/man/is.wimids.Rd
+++ b/man/is.wimids.Rd
@@ -19,10 +19,7 @@ This function returns a logical value indicating whether \code{object} is of the
 The class of objects is checked to be of the \code{wimids}.
 }
 \examples{
-\donttest{#Loading libraries
-library(MatchThem)
-
-#Loading the dataset
+\donttest{#Loading the dataset
 data(osteoarthritis)
 
 #Multiply imputing the missing values
@@ -32,7 +29,7 @@ imputed.datasets <- mice::mice(osteoarthritis, m = 5)
 weighted.datasets <- weightthem(OSP ~ AGE + SEX + BMI + RAC + SMK,
                                 imputed.datasets,
                                 approach = 'within',
-                                method = 'ps',
+                                method = 'glm',
                                 estimand = "ATT")
 
 #Checking the 'weighted.datasets' object

--- a/man/matchthem.Rd
+++ b/man/matchthem.Rd
@@ -44,9 +44,6 @@ If an \code{amelia} object is supplied to \code{datasets}, it will be transforme
 \examples{
 \donttest{#1
 
-#Loading libraries
-library(MatchThem)
-
 #Loading the dataset
 data(osteoarthritis)
 
@@ -60,9 +57,6 @@ matched.datasets <- matchthem(OSP ~ AGE + SEX + BMI + RAC + SMK,
                               method = 'nearest')
 
 #2
-
-#Loading libraries
-library(MatchThem)
 
 #Loading the dataset
 data(osteoarthritis)

--- a/man/pool.Rd
+++ b/man/pool.Rd
@@ -29,9 +29,6 @@ This function returns an object from the \code{mimipo} class. Methods for \code{
 }
 \examples{
 \donttest{#Loading libraries
-library(MatchThem)
-library(survey)
-
 #Loading the dataset
 data(osteoarthritis)
 
@@ -42,11 +39,12 @@ imputed.datasets <- mice::mice(osteoarthritis, m = 5)
 weighted.datasets <- weightthem(OSP ~ AGE + SEX + BMI + RAC + SMK,
                                 imputed.datasets,
                                 approach = 'within',
-                                method = 'ps')
+                                method = 'glm')
 
 #Analyzing the weighted datasets
 models <- with(weighted.datasets,
-               svyglm(KOA ~ OSP, family = quasibinomial))
+               WeightIt::glm_weightit(KOA ~ OSP,
+                                      family = binomial))
 
 #Pooling results obtained from analyzing the datasets
 results <- pool(models)

--- a/man/trim.Rd
+++ b/man/trim.Rd
@@ -5,18 +5,19 @@
 \alias{trim.wimids}
 \title{Trim Weights}
 \usage{
-\method{trim}{wimids}(w, at = 0, lower = FALSE, ...)
+\method{trim}{wimids}(x, at = 0, lower = FALSE, ...)
 }
 \arguments{
-\item{w}{A \code{wimids} object; the output of a call to \code{\link[=weightthem]{weightthem()}}.}
+\item{x}{A \code{wimids} object; the output of a call to \code{\link[=weightthem]{weightthem()}}.}
 
-\item{at}{
-\code{numeric}; either the quantile of the weights above which weights are to be trimmed. A single number between .5 and 1, or the number of weights to be trimmed (e.g., \code{at = 3} for the top 3 weights to be set to the 4th largest weight).
-}
+\item{at}{\code{numeric}; either the quantile of the weights above which
+weights are to be trimmed. A single number between .5 and 1, or the number
+of weights to be trimmed (e.g., \code{at = 3} for the top 3 weights to be
+set to the 4th largest weight).}
 
-\item{lower}{
-\code{logical}; whether also to trim at the lower quantile (e.g., for \code{at = .9}, trimming at both .1 and .9, or for \code{at = 3}, trimming the top and bottom 3 weights).
-}
+\item{lower}{\code{logical}; whether also to trim at the lower quantile
+(e.g., for \code{at = .9}, trimming at both .1 and .9, or for \code{at = 3},
+trimming the top and bottom 3 weights). Default is \code{FALSE} to only trim the higher weights.}
 
 \item{...}{Ignored.}
 }
@@ -30,10 +31,7 @@ Trims (i.e., truncates) large weights by setting all weights higher than that at
 \code{trim.wimids()} works by calling \code{\link[WeightIt:trim]{WeightIt::trim()}} on each \code{weightit} object stored in the \code{models} component of the \code{wimids} object. Because \code{trim()} itself is not exported from \pkg{MatchThem}, it must be called using \code{WeightIt::trim()} or by attaching \pkg{WeightIt} (i.e., running \code{library(WeightIt)}) before use.
 }
 \examples{
-\donttest{#Loading libraries
-library(MatchThem)
-
-#Loading the dataset
+\donttest{#Loading the dataset
 data(osteoarthritis)
 
 #Multiply imputing the missing values
@@ -43,7 +41,7 @@ imputed.datasets <- mice::mice(osteoarthritis, m = 5)
 weighted.datasets <- weightthem(OSP ~ AGE + SEX + BMI + RAC + SMK,
                                 imputed.datasets,
                                 approach = 'within',
-                                method = 'ps',
+                                method = 'glm',
                                 estimand = "ATE")
 
 #Trimming the top 10\% of weights in each dataset

--- a/man/weightthem.Rd
+++ b/man/weightthem.Rd
@@ -4,7 +4,7 @@
 \alias{weightthem}
 \title{Weights Multiply Imputed Datasets}
 \usage{
-weightthem(formula, datasets, approach = "within", method = "ps", ...)
+weightthem(formula, datasets, approach = "within", method = "glm", ...)
 }
 \arguments{
 \item{formula}{A \code{formula} of the form \code{z ~ x1 + x2}, where \code{z} is the exposure and \code{x1} and \code{x2} are the covariates to be balanced, which is passed directly to \code{\link[WeightIt:weightit]{WeightIt::weightit()}} to specify the propensity score model or treatment and covariates to be used to estimate the weights. See \code{\link[WeightIt:weightit]{WeightIt::weightit()}} for details.}
@@ -13,7 +13,7 @@ weightthem(formula, datasets, approach = "within", method = "ps", ...)
 
 \item{approach}{The approach used to combine information in multiply imputed datasets. Currently, \code{"within"} (estimating weights within each dataset), \code{"across"} (estimating propensity scores within each dataset, averaging them across datasets, and computing a single set of weights based on that to be applied to all datasets), and \code{"apw"} (or averaging the probability weights, estimating weights within each dataset and averaging them across datasets) approaches are available. The default is \code{"within"}, which has been shown to have superior performance in most cases.}
 
-\item{method}{The method used to estimate weights. See \code{\link[WeightIt:weightit]{WeightIt::weightit()}} for allowable options. Only methods that produce a propensity score (\code{"ps"}, \code{"gbm"}, \code{"cbps"}, \code{"super"}, and \code{"bart"}) are compatible with the \code{"across"} approach). The default is \code{"ps"} propensity score weighting using logistic regression propensity scores.}
+\item{method}{The method used to estimate weights. See \code{\link[WeightIt:weightit]{WeightIt::weightit()}} for allowable options. Only methods that produce a propensity score (\code{"glm"}, \code{"gbm"}, \code{"ipt"} \code{"cbps"}, \code{"super"}, and \code{"bart"}) are compatible with the \code{"across"} approach). The default is \code{"glm"} propensity score weighting using logistic regression propensity scores.}
 
 \item{...}{Additional arguments to be passed to \code{weightit()}. see \code{\link[WeightIt:weightit]{WeightIt::weightit()}} for more details.}
 }
@@ -29,9 +29,6 @@ If an \code{amelia} object is supplied to \code{datasets}, it will be transforme
 \examples{
 \donttest{#1
 
-#Loading libraries
-library(MatchThem)
-
 #Loading the dataset
 data(osteoarthritis)
 
@@ -46,9 +43,6 @@ weighted.datasets <- weightthem(OSP ~ AGE + SEX + BMI + RAC + SMK,
                                 estimand = 'ATT')
 
 #2
-
-#Loading libraries
-library(MatchThem)
 
 #Loading the dataset
 data(osteoarthritis)

--- a/man/with.Rd
+++ b/man/with.Rd
@@ -35,11 +35,10 @@ An object from the \code{mimira} class containing the output of the analyses.
 \details{
 \code{with()} applies the supplied model in \code{expr} to the (matched or weighted) multiply imputed datasets, automatically incorporating the (matching) weights when possible. The argument to \code{expr} should be of the form \code{glm(y ~ z, family = quasibinomial)}, for example, excluding the data or weights argument, which are automatically supplied. \cr
 Functions from the \pkg{survey} package, such as \code{svyglm()}, are treated a bit differently. No \code{svydesign} object needs to be supplied because \code{with()} automatically constructs and supplies it with the imputed dataset and estimated weights. When \code{cluster = TRUE} (or \code{with()} detects that pairs should be clustered; see the \code{cluster} argument above), pair membership is supplied to the \code{ids} argument of \code{svydesign()}. \cr
-For generalized linear models, it is always recommended to use \code{svyglm()} rather than \code{glm()} in order to correctly compute standard errors. For Cox models, \code{coxph()} will produce correct standard errors when used with weighting but \code{svycoxph()} will produce more accurate standard errors when matching is used.
+After weighting using \code{weightthem()}, \code{glm_weightit()} should be used as the modeling function to fit generalized lienar models. It correctly produces robust standard errors that account for estimation of the weights, if possible. See \code{\link[WeightIt:glm_weightit]{WeightIt::glm_weightit()}} for details. Otherwise, \code{svyglm()} should be used rather than \code{glm()} in order to correctly compute standard errors. For Cox models, \code{coxph()} will produce approximately correct standard errors when used with weighting but \code{svycoxph()} will produce more accurate standard errors when matching is used.
 }
 \examples{
 \donttest{#Loading libraries
-library(MatchThem)
 library(survey)
 
 #Loading the dataset
@@ -57,7 +56,19 @@ matched.datasets <- matchthem(OSP ~ AGE + SEX + BMI + RAC + SMK,
 #Analyzing the matched datasets
 models <- with(matched.datasets,
                svyglm(KOA ~ OSP, family = binomial),
-               cluster = TRUE)}
+               cluster = TRUE)
+
+#Weghting in the multiply imputed datasets
+weighted.datasets <- weightthem(OSP ~ AGE + SEX + BMI + RAC + SMK,
+                               imputed.datasets,
+                               approach = 'within',
+                               method = 'glm')
+
+#Analyzing the matched datasets
+models <- with(weighted.datasets,
+               WeightIt::glm_weightit(KOA ~ OSP,
+                                      family = binomial))
+}
 }
 \references{
 Stef van Buuren and Karin Groothuis-Oudshoorn (2011). \code{mice}: Multivariate Imputation by Chained Equations in \code{R}. \emph{Journal of Statistical Software}, 45(3): 1-67. \doi{10.18637/jss.v045.i03}


### PR DESCRIPTION
I mentioned this in my email to you, but just to recap, the main changes are:
* Changing the argument names for `trim()` to match those in `WeightIt`
* Adding support for `glm_weightit()` in `with()`
* Adding support for new weighting methods
* Minor adjustments to documentation
Let me know if you have any questions.